### PR TITLE
feat: improve readability

### DIFF
--- a/SyntaxAutoFix/syntaxautofix.py
+++ b/SyntaxAutoFix/syntaxautofix.py
@@ -20,17 +20,17 @@ logger = logging.getLogger("SyntaxAutoFix")
 script_path = os.path.dirname(os.path.realpath(__file__))
 
 
-def getHomePath():
-    user = os.getenv("SUDO_USER") or os.getenv("USER")
-    home = os.path.join(os.path.expanduser('~' + user), '.config/SyntaxAutoFix')
-    if not os.path.exists(home):
-        os.mkdir(home)
-    return home
+def getProjectPath():
+    home = os.getenv("HOME")
+    project_path = os.path.join(home, ".config/SyntaxAutoFix")
+    if not os.path.exists(project_path):
+        os.mkdir(project_path)
+    return project_path
 
 
 def getAssetPath(path):
-    home = getHomePath()
-    complete_path = os.path.join(home, path)
+    project_path = getProjectPath()
+    complete_path = os.path.join(project_path, path)
     if not os.path.exists(complete_path):
         complete_path = os.path.join(script_path, path)
     return complete_path
@@ -67,7 +67,7 @@ files = {}
 
 def get_wrong_word(recorded_words_list):
     if len(recorded_words_list) > 0:
-        list_splitted = recorded_words_list[0].split() #Get first element of the list
+        list_splitted = recorded_words_list[0].split()  # Get first element of the list
         if len(list_splitted) > 0:
             wrong_word = list_splitted[-1]
             return wrong_word
@@ -81,7 +81,7 @@ def mispell_callback():
     wrong_word = get_wrong_word(recorded_words_list)
     if wrong_word:
         logger.info(f"Word '{wrong_word}' detected and tracked")
-        save_stats_file(os.path.join(getHomePath(), "stats.json"), wrong_word, 1)
+        save_stats_file(os.path.join(getProjectPath(), "stats.json"), wrong_word, 1)
     keyboard.start_recording()
 
 

--- a/validateterms.py
+++ b/validateterms.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import logging
 import os.path
 from SyntaxAutoFix.utils import open_typo_file
 
@@ -10,7 +11,7 @@ def parse_argument(_parser_):
     return args
 
 
-def load_language(_args_):
+def load_language(_args_, script_path):
     try:
         lang_path = script_path + _args_.lang + '.json'
         words = open_typo_file(lang_path)
@@ -22,24 +23,29 @@ def load_language(_args_):
 def term_is_typo_of_another_word(term, words):
     for (correct, wrongs) in words.items():
         if correct == term:
-            print('ERR 1: The term ' + correct + ' is a typo of ' + term + '.')
+            logging.info(f"ERR 1: The term '{correct}' is a typo of '{term}'.")
         for wrong in wrongs:
-            if wrong == '':
-                print('ERR 3: The term ' + correct + ' has an empty typo.')
+            if not wrong:
+                logging.info(f"ERR 3: The term '{correct}' has an empty typo.")
 
 
-# Parse argument
-parser = argparse.ArgumentParser(description='validate terms!')
-args = parse_argument(parser)
+def main():
+    # Parse argument
+    parser = argparse.ArgumentParser(description='validate terms!')
+    args = parse_argument(parser)
 
-# Store argument
-script_path = os.path.dirname(os.path.realpath(__file__))
-script_path = os.path.join(script_path, 'SyntaxAutoFix/words/')
-words = load_language(args)
-for (correct, wrongs) in words.items():
-    for wrong in wrongs:
-        if wrong == correct:
-            print('ERR 2: The term ' + correct + ' his a typo of itself.')
-            continue
-        if wrong != '':
-            term_is_typo_of_another_word(wrong, words)
+    # Store argument
+    script_path = os.path.dirname(os.path.realpath(__file__))
+    script_path = os.path.join(script_path, 'SyntaxAutoFix/words/')
+    words = load_language(args, script_path)
+    for (correct, wrongs) in words.items():
+        for wrong in wrongs:
+            if wrong == correct:
+                logging.info(f"ERR 2: The term '{correct}' is a typo of itself.")
+                continue
+            if wrong:
+                term_is_typo_of_another_word(wrong, words)
+
+
+if __name__ == "__main__":
+    main()

--- a/validateterms.py
+++ b/validateterms.py
@@ -17,7 +17,7 @@ def load_language(_args_, script_path):
         words = open_typo_file(lang_path)
         return words
     except FileNotFoundError:
-        raise ValueError('Language ' + _args_.lang + ' actually not avalaible.')
+        raise ValueError(f"Language '{ _args_.lang}' is not available.")
 
 
 def term_is_typo_of_another_word(term, words):
@@ -41,7 +41,9 @@ def main():
     for (correct, wrongs) in words.items():
         for wrong in wrongs:
             if wrong == correct:
-                logging.info(f"ERR 2: The term '{correct}' is a typo of itself.")
+                logging.info(
+                    f"ERR 2: The term '{correct}' is a typo of itself."
+                )
                 continue
             if wrong:
                 term_is_typo_of_another_word(wrong, words)


### PR DESCRIPTION
The arg parser in the middle of the syntaxautofix.py file is confusing, I think it should be in the main().
Also it can happen that the program captures a list with more than 1 misspelled word and the current way in which the program works it will only capture one.
For example:
`[' volete ovltnoari', 'ciao vorrano']` only ovltnoari will be captures but actually both ovltnoari and vorrano should be captured